### PR TITLE
Define `PackedOutput` enum

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/bootloader_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader_hints.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use felt::Felt252;
 use serde::Deserialize;
 
 use crate::hint_processor::builtin_hint_processor::hint_utils::insert_value_from_var_name;
@@ -33,8 +34,9 @@ pub struct BootloaderConfig {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct PackedOutput {
-    // TODO: missing definitions of PlainPackedOutput, CompositePackedOutput
+pub enum PackedOutput {
+    Plain(Vec<Felt252>),
+    Composite(Vec<Felt252>),
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Replace the empty struct implementation by an enum. This will require more fleshing out later but allows to implement asserts on output types.

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

