### PR TITLE
Execute task hint #6: exit scope

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -891,6 +891,7 @@ impl HintProcessorLogic for BuiltinHintProcessor {
             hint_code::SIMPLE_BOOTLOADER_SET_CURRENT_TASK => {
                 set_current_task(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
             }
+            hint_code::EXECUTE_TASK_EXIT_SCOPE => exit_scope(exec_scopes),
             #[cfg(feature = "skip_next_instruction_hint")]
             hint_code::SKIP_NEXT_INSTRUCTION => skip_next_instruction(vm),
             code => Err(HintError::UnknownHint(code.to_string().into_boxed_str())),


### PR DESCRIPTION
Map the hint identifier to the already implemented hint. The comment inside the hint forces us to use a custom hint identifier.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

