### PR TITLE
Bootloader hint #7: compute fact topologies

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/bootloader_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/bootloader_hints.rs
@@ -1,6 +1,9 @@
 use std::any::Any;
 use std::collections::HashMap;
 
+use crate::hint_processor::builtin_hint_processor::bootloader::fact_topologies::{
+    compute_fact_topologies, configure_fact_topologies, write_to_fact_topologies_file, FactTopology,
+};
 use felt::Felt252;
 use num_traits::ToPrimitive;
 
@@ -268,7 +271,7 @@ pub fn save_output_pointer(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let output_ptr = get_ptr_from_var_name("output_ptr", vm, ids_data, ap_tracking)?;
-    exec_scopes.insert_value("output_start", output_ptr);
+    exec_scopes.insert_value(vars::OUTPUT_START, output_ptr);
     Ok(())
 }
 
@@ -282,6 +285,63 @@ pub fn save_packed_outputs(exec_scopes: &mut ExecutionScopes) -> Result<(), Hint
     let bootloader_input: BootloaderInput = exec_scopes.get("bootloader_input")?;
     let packed_outputs = bootloader_input.packed_outputs;
     exec_scopes.insert_value("packed_outputs", packed_outputs);
+    Ok(())
+}
+
+/// Implements
+/// const COMPUTE_FACT_TOPOLOGIES: &str = "from typing import List
+///
+/// from starkware.cairo.bootloaders.bootloader.utils import compute_fact_topologies
+/// from starkware.cairo.bootloaders.fact_topology import FactTopology
+/// from starkware.cairo.bootloaders.simple_bootloader.utils import (
+///     configure_fact_topologies,
+///     write_to_fact_topologies_file,
+/// )
+///
+/// # Compute the fact topologies of the plain packed outputs based on packed_outputs and
+/// # fact_topologies of the inner tasks.
+/// plain_fact_topologies: List[FactTopology] = compute_fact_topologies(
+///     packed_outputs=packed_outputs, fact_topologies=fact_topologies,
+/// )
+///
+/// # Configure the memory pages in the output builtin, based on plain_fact_topologies.
+/// configure_fact_topologies(
+///     fact_topologies=plain_fact_topologies, output_start=output_start,
+///     output_builtin=output_builtin,
+/// )
+///
+/// # Dump fact topologies to a json file.
+/// if bootloader_input.fact_topologies_path is not None:
+///     write_to_fact_topologies_file(
+///         fact_topologies_path=bootloader_input.fact_topologies_path,
+///         fact_topologies=plain_fact_topologies,
+///     )";
+pub fn compute_and_configure_fact_topologies(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+) -> Result<(), HintError> {
+    let bootloader_input: BootloaderInput = exec_scopes.get(vars::BOOTLOADER_INPUT)?;
+    let packed_outputs: Vec<PackedOutput> = exec_scopes.get(vars::PACKED_OUTPUTS)?;
+    let fact_topologies: Vec<FactTopology> = exec_scopes.get(vars::FACT_TOPOLOGIES)?;
+    let mut output_start: Relocatable = exec_scopes.get(vars::OUTPUT_START)?;
+    let output_builtin = vm.get_output_builtin()?;
+
+    let plain_fact_topologies = compute_fact_topologies(&packed_outputs, &fact_topologies)
+        .map_err(Into::<HintError>::into)?;
+
+    configure_fact_topologies(&plain_fact_topologies, &mut output_start, output_builtin)
+        .map_err(Into::<HintError>::into)?;
+
+    exec_scopes.insert_value(vars::OUTPUT_START, output_start);
+
+    if let Some(path) = bootloader_input
+        .simple_bootloader_input
+        .fact_topologies_path
+    {
+        write_to_fact_topologies_file(path.as_path(), &plain_fact_topologies)
+            .map_err(Into::<HintError>::into)?;
+    }
+
     Ok(())
 }
 
@@ -382,6 +442,7 @@ mod tests {
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::*;
     use crate::vm::runners::builtin_runner::BuiltinRunner;
+    use crate::vm::runners::cairo_pie::PublicMemoryPage;
     use crate::vm::vm_core::VirtualMachine;
     use crate::{any_box, relocatable};
     use assert_matches::assert_matches;
@@ -720,7 +781,7 @@ mod tests {
     }
 
     #[test]
-    fn test_save_packed_ouputs() {
+    fn test_save_packed_outputs() {
         let packed_outputs = vec![
             PackedOutput::Plain(Default::default()),
             PackedOutput::Plain(Default::default()),
@@ -769,6 +830,56 @@ mod tests {
         assert_eq!(
             saved_packed_outputs.expect("asserted Ok above, qed").len(),
             3
+        );
+    }
+
+    #[rstest]
+    fn test_compute_and_configure_fact_topologies(bootloader_input: BootloaderInput) {
+        let mut vm = vm!();
+        let mut output_builtin = OutputBuiltinRunner::new(true);
+        output_builtin.initialize_segments(&mut vm.segments);
+        vm.builtin_runners
+            .push(BuiltinRunner::Output(output_builtin.clone()));
+
+        let mut exec_scopes = ExecutionScopes::new();
+        let packed_outputs = vec![PackedOutput::Plain(vec![]), PackedOutput::Plain(vec![])];
+        let fact_topologies = vec![
+            FactTopology {
+                tree_structure: vec![],
+                page_sizes: vec![3usize, 1usize],
+            },
+            FactTopology {
+                tree_structure: vec![],
+                page_sizes: vec![10usize],
+            },
+        ];
+        let output_start = Relocatable {
+            segment_index: output_builtin.base() as isize,
+            offset: 0,
+        };
+        exec_scopes.insert_value(vars::BOOTLOADER_INPUT, bootloader_input);
+        exec_scopes.insert_value(vars::PACKED_OUTPUTS, packed_outputs);
+        exec_scopes.insert_value(vars::FACT_TOPOLOGIES, fact_topologies);
+        exec_scopes.insert_value(vars::OUTPUT_START, output_start);
+
+        compute_and_configure_fact_topologies(&mut vm, &mut exec_scopes)
+            .expect("Hint failed unexpectedly");
+
+        let output_start: Relocatable = exec_scopes.get(vars::OUTPUT_START).unwrap();
+        assert_eq!(
+            output_start,
+            Relocatable {
+                segment_index: 0,
+                offset: 18
+            }
+        );
+        assert_eq!(
+            vm.get_output_builtin().unwrap().pages,
+            HashMap::from([
+                (1, PublicMemoryPage { start: 2, size: 3 }),
+                (2, PublicMemoryPage { start: 5, size: 1 }),
+                (3, PublicMemoryPage { start: 8, size: 10 }),
+            ])
         );
     }
 

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/bootloader_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/bootloader_hints.rs
@@ -289,8 +289,6 @@ pub fn save_packed_outputs(exec_scopes: &mut ExecutionScopes) -> Result<(), Hint
 }
 
 /// Implements
-/// const COMPUTE_FACT_TOPOLOGIES: &str = "from typing import List
-///
 /// from starkware.cairo.bootloaders.bootloader.utils import compute_fact_topologies
 /// from starkware.cairo.bootloaders.fact_topology import FactTopology
 /// from starkware.cairo.bootloaders.simple_bootloader.utils import (
@@ -315,7 +313,7 @@ pub fn save_packed_outputs(exec_scopes: &mut ExecutionScopes) -> Result<(), Hint
 ///     write_to_fact_topologies_file(
 ///         fact_topologies_path=bootloader_input.fact_topologies_path,
 ///         fact_topologies=plain_fact_topologies,
-///     )";
+///     )
 pub fn compute_and_configure_fact_topologies(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/fact_topologies.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/fact_topologies.rs
@@ -1,0 +1,346 @@
+use crate::hint_processor::builtin_hint_processor::bootloader::types::PackedOutput;
+use crate::types::errors::math_errors::MathError;
+use crate::types::relocatable::Relocatable;
+use crate::vm::errors::hint_errors::HintError;
+use crate::vm::errors::runner_errors::RunnerError;
+use crate::vm::runners::builtin_runner::OutputBuiltinRunner;
+use felt::Felt252;
+use serde::Serialize;
+use std::fs::File;
+use std::path::Path;
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FactTopology {
+    #[allow(dead_code)]
+    pub tree_structure: Vec<Felt252>,
+    pub page_sizes: Vec<usize>,
+}
+
+#[derive(Serialize)]
+struct FactTopologyFile<'a> {
+    fact_topologies: Vec<&'a FactTopology>,
+}
+
+impl AsRef<FactTopology> for FactTopology {
+    fn as_ref(&self) -> &FactTopology {
+        self
+    }
+}
+
+#[derive(Debug, thiserror_no_std::Error)]
+pub enum FactTopologyError {
+    #[error("Expected {0} fact topologies but got {1}")]
+    WrongNumberOfFactTopologies(usize, usize),
+
+    #[error("Composite packed outputs are not supported yet")]
+    CompositePackedOutputNotSupported(PackedOutput),
+
+    #[error("Could not add page to output: {0}")]
+    FailedToAddOutputPage(#[from] RunnerError),
+
+    #[error(transparent)]
+    Math(#[from] MathError),
+}
+
+impl Into<HintError> for FactTopologyError {
+    fn into(self) -> HintError {
+        match self {
+            FactTopologyError::WrongNumberOfFactTopologies(_, _) => {
+                HintError::AssertionFailed(self.to_string().into_boxed_str())
+            }
+            FactTopologyError::CompositePackedOutputNotSupported(_) => HintError::CustomHint(
+                "Cannot compute fact topologies for composite packed outputs (yet)"
+                    .to_string()
+                    .into_boxed_str(),
+            ),
+            FactTopologyError::FailedToAddOutputPage(e) => HintError::CustomHint(
+                format!("Cannot add output page to output segment: {}", e).into_boxed_str(),
+            ),
+            FactTopologyError::Math(e) => HintError::Math(e),
+        }
+    }
+}
+
+#[derive(thiserror_no_std::Error, Debug)]
+pub enum WriteFactTopologiesError {
+    #[error("Failed to create fact topology file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Failed to serialize fact topologies: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl Into<HintError> for WriteFactTopologiesError {
+    fn into(self) -> HintError {
+        HintError::CustomHint(self.to_string().into_boxed_str())
+    }
+}
+
+/// Flattens and extracts the fact topologies from packed outputs.
+///
+/// Note that `packed_outputs` and `fact_topologies` must have the same length.
+///
+/// * `packed_outputs`: Packed outputs.
+/// * `fact_topologies`: Fact topologies.
+pub fn compute_fact_topologies<'a>(
+    packed_outputs: &Vec<PackedOutput>,
+    fact_topologies: &'a Vec<FactTopology>,
+) -> Result<Vec<&'a FactTopology>, FactTopologyError> {
+    if packed_outputs.len() != fact_topologies.len() {
+        return Err(FactTopologyError::WrongNumberOfFactTopologies(
+            packed_outputs.len(),
+            fact_topologies.len(),
+        ));
+    }
+
+    let mut plain_fact_topologies = vec![];
+
+    for (packed_output, fact_topology) in std::iter::zip(packed_outputs, fact_topologies) {
+        match packed_output {
+            PackedOutput::Plain(_) => {
+                plain_fact_topologies.push(fact_topology);
+            }
+            PackedOutput::Composite(_) => {
+                return Err(FactTopologyError::CompositePackedOutputNotSupported(
+                    packed_output.clone(),
+                ));
+            }
+        }
+    }
+
+    Ok(plain_fact_topologies)
+}
+
+/// Adds page to the output builtin for the specified fact topology.
+///
+/// * `fact_topology`: Fact topology.
+/// * `output_builtin`: Output builtin of the VM.
+/// * `current_page_id`: First page ID to use.
+/// * `output_start`: Start of the output range for this fact topology.
+///
+/// Reimplements the following Python code:
+///     offset = 0
+///     for i, page_size in enumerate(fact_topology.page_sizes):
+///         output_builtin.add_page(
+///             page_id=cur_page_id + i, page_start=output_start + offset, page_size=page_size
+///         )
+///         offset += page_size
+///
+///     return len(fact_topology.page_sizes)
+fn add_consecutive_output_pages(
+    fact_topology: &FactTopology,
+    output_builtin: &mut OutputBuiltinRunner,
+    current_page_id: usize,
+    output_start: &Relocatable,
+) -> Result<usize, FactTopologyError> {
+    let mut offset = 0;
+
+    for (i, page_size) in fact_topology.page_sizes.iter().copied().enumerate() {
+        let page_id = current_page_id + i;
+        let page_start = output_start + offset;
+        output_builtin.add_page(page_id, page_start, page_size)?;
+        offset += page_size;
+    }
+
+    Ok(fact_topology.page_sizes.len())
+}
+
+/// Given the fact_topologies of the tasks that were run by bootloader, configure the
+/// corresponding pages in the output builtin.
+///
+/// Assumes that the bootloader output 2 words per task.
+///
+/// * `plain_fact_topologies`: Fact topologies.
+/// * `output_start`: Start of the bootloader output.
+/// * `output_builtin`: Output builtin of the VM.
+///
+/// Reimplements the following Python code:
+/// cur_page_id = 1
+/// for fact_topology in fact_topologies:
+///     # Skip bootloader output for each task.
+///     output_start += 2
+///     cur_page_id += add_consecutive_output_pages(
+///         fact_topology=fact_topology,
+///         output_builtin=output_builtin,
+///         cur_page_id=cur_page_id,
+///         output_start=output_start,
+///     )
+///     output_start += sum(fact_topology.page_sizes)
+
+pub fn configure_fact_topologies<FT: AsRef<FactTopology>>(
+    plain_fact_topologies: &[FT],
+    output_start: &mut Relocatable,
+    output_builtin: &mut OutputBuiltinRunner,
+) -> Result<(), FactTopologyError> {
+    // Each task may use a few memory pages. Start from page 1 (as page 0 is reserved for the
+    // bootloader program and arguments).
+    let mut current_page_id: usize = 1;
+    for fact_topology in plain_fact_topologies {
+        // Skip bootloader output for each task
+        *output_start = (*output_start + 2usize)?;
+
+        current_page_id += add_consecutive_output_pages(
+            fact_topology.as_ref(),
+            output_builtin,
+            current_page_id,
+            output_start,
+        )?;
+        let total_page_sizes: usize = fact_topology.as_ref().page_sizes.iter().sum();
+        *output_start = (*output_start + total_page_sizes)?;
+    }
+
+    Ok(())
+}
+
+/// Writes fact topologies to a file, as JSON.
+///
+/// * `path`: File path.
+/// * `fact_topologies`: Fact topologies to write.
+pub fn write_to_fact_topologies_file<FT: AsRef<FactTopology>>(
+    path: &Path,
+    fact_topologies: &Vec<FT>,
+) -> Result<(), WriteFactTopologiesError> {
+    let mut file = File::create(path)?;
+    let fact_topology_file = FactTopologyFile {
+        fact_topologies: fact_topologies.iter().map(|ft| ft.as_ref()).collect(),
+    };
+    serde_json::to_writer(&mut file, &fact_topology_file)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hint_processor::builtin_hint_processor::bootloader::types::PackedOutput;
+    use crate::vm::runners::cairo_pie::PublicMemoryPage;
+    use rstest::{fixture, rstest};
+    use std::collections::HashMap;
+
+    #[fixture]
+    fn packed_outputs() -> Vec<PackedOutput> {
+        vec![
+            PackedOutput::Plain(vec![]),
+            PackedOutput::Plain(vec![]),
+            PackedOutput::Plain(vec![]),
+        ]
+    }
+
+    #[fixture]
+    fn fact_topologies() -> Vec<FactTopology> {
+        vec![
+            FactTopology {
+                tree_structure: vec![],
+                page_sizes: vec![1usize],
+            },
+            FactTopology {
+                tree_structure: vec![],
+                page_sizes: vec![1usize, 2usize],
+            },
+            FactTopology {
+                tree_structure: vec![],
+                page_sizes: vec![3usize],
+            },
+        ]
+    }
+
+    #[rstest]
+    fn test_compute_fact_topologies(
+        packed_outputs: Vec<PackedOutput>,
+        fact_topologies: Vec<FactTopology>,
+    ) {
+        let plain_fact_topologies = compute_fact_topologies(&packed_outputs, &fact_topologies)
+            .expect("Failed to compute fact topologies");
+        for (topology, plain_topology) in std::iter::zip(&fact_topologies, plain_fact_topologies) {
+            assert_eq!(topology, plain_topology);
+        }
+    }
+
+    #[test]
+    /// Composite outputs are not supported (yet).
+    fn test_compute_fact_topologies_composite_output() {
+        let packed_outputs = vec![PackedOutput::Composite(vec![])];
+        let fact_topologies = vec![FactTopology {
+            tree_structure: vec![],
+            page_sizes: vec![],
+        }];
+        let result = compute_fact_topologies(&packed_outputs, &fact_topologies);
+        assert!(matches!(
+            result,
+            Err(FactTopologyError::CompositePackedOutputNotSupported(_))
+        ));
+    }
+
+    #[test]
+    /// Both arguments to `compute_fact_topologies` must have the same length.
+    fn test_compute_fact_topologies_arg_len_mismatch() {
+        let packed_outputs = vec![PackedOutput::Plain(vec![])];
+        let fact_topologies = vec![];
+
+        let result = compute_fact_topologies(&packed_outputs, &fact_topologies);
+        assert!(
+            matches!(result, Err(FactTopologyError::WrongNumberOfFactTopologies(n_outputs, n_topologies)) if n_outputs == packed_outputs.len() && n_topologies == fact_topologies.len())
+        )
+    }
+
+    #[rstest]
+    fn test_add_consecutive_output_pages() {
+        let fact_topology = FactTopology {
+            tree_structure: vec![],
+            page_sizes: vec![1usize, 2usize, 1usize],
+        };
+        let mut output_builtin = OutputBuiltinRunner::new(true);
+        let page_id = 1;
+        let output_start = Relocatable {
+            segment_index: 0,
+            offset: 10,
+        };
+
+        let result = add_consecutive_output_pages(
+            &fact_topology,
+            &mut output_builtin,
+            page_id,
+            &output_start,
+        )
+        .expect("Adding consecutive output pages failed unexpectedly");
+        assert_eq!(result, fact_topology.page_sizes.len());
+
+        assert_eq!(
+            output_builtin.pages,
+            HashMap::from([
+                (1, PublicMemoryPage { start: 10, size: 1 }),
+                (2, PublicMemoryPage { start: 11, size: 2 }),
+                (3, PublicMemoryPage { start: 13, size: 1 })
+            ])
+        );
+    }
+
+    #[rstest]
+    fn test_configure_fact_topologies(fact_topologies: Vec<FactTopology>) {
+        let mut output_builtin = OutputBuiltinRunner::new(true);
+        let mut output_start = Relocatable {
+            segment_index: output_builtin.base() as isize,
+            offset: 10,
+        };
+
+        let result =
+            configure_fact_topologies(&fact_topologies, &mut output_start, &mut output_builtin)
+                .expect("Configuring fact topologies failed unexpectedly");
+
+        assert_eq!(result, ());
+
+        // We expect the offset to 2 + sum(page_sizes) for each fact topology
+        let expected_offset: usize = fact_topologies.iter().flat_map(|ft| &ft.page_sizes).sum();
+        let expected_offset = expected_offset + fact_topologies.len() * 2;
+        assert_eq!(output_start.segment_index, output_builtin.base() as isize);
+        assert_eq!(output_start.offset, 10 + expected_offset);
+
+        assert_eq!(
+            output_builtin.pages,
+            HashMap::from([
+                (1, PublicMemoryPage { start: 12, size: 1 }),
+                (2, PublicMemoryPage { start: 15, size: 1 }),
+                (3, PublicMemoryPage { start: 16, size: 2 }),
+                (4, PublicMemoryPage { start: 20, size: 3 })
+            ])
+        );
+    }
+}

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/mod.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod bootloader_hints;
 pub(crate) mod execute_task_hints;
+mod fact_topologies;
 pub(crate) mod simple_bootloader_hints;
 pub(crate) mod types;
 pub(crate) mod vars;

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/simple_bootloader_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/simple_bootloader_hints.rs
@@ -2,11 +2,10 @@ use num_integer::Integer;
 use num_traits::ToPrimitive;
 use std::collections::HashMap;
 
+use crate::hint_processor::builtin_hint_processor::bootloader::fact_topologies::FactTopology;
 use felt::Felt252;
 
-use crate::hint_processor::builtin_hint_processor::bootloader::types::{
-    FactTopology, SimpleBootloaderInput,
-};
+use crate::hint_processor::builtin_hint_processor::bootloader::types::SimpleBootloaderInput;
 use crate::hint_processor::builtin_hint_processor::bootloader::vars;
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
     get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
@@ -134,6 +133,7 @@ mod tests {
     use num_traits::ToPrimitive;
     use std::collections::HashMap;
 
+    use crate::hint_processor::builtin_hint_processor::bootloader::fact_topologies::FactTopology;
     use felt::Felt252;
     use rstest::{fixture, rstest};
 
@@ -142,7 +142,7 @@ mod tests {
         set_tasks_variable,
     };
     use crate::hint_processor::builtin_hint_processor::bootloader::types::{
-        FactTopology, SimpleBootloaderInput, Task, TaskSpec,
+        SimpleBootloaderInput, Task, TaskSpec,
     };
     use crate::hint_processor::builtin_hint_processor::bootloader::vars;
     use crate::hint_processor::builtin_hint_processor::hint_utils::{

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/types.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/types.rs
@@ -1,5 +1,6 @@
 use felt::Felt252;
 use serde::Deserialize;
+use std::path::PathBuf;
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct BootloaderConfig {
@@ -21,9 +22,6 @@ impl PackedOutput {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct FactTopology {}
-
-#[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct Task {}
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -39,7 +37,7 @@ impl TaskSpec {
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct SimpleBootloaderInput {
-    pub fact_topologies_path: Option<String>,
+    pub fact_topologies_path: Option<PathBuf>,
     pub single_page: bool,
     pub tasks: Vec<TaskSpec>,
 }

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/vars.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/vars.rs
@@ -4,6 +4,9 @@ pub(crate) const BOOTLOADER_INPUT: &str = "bootloader_input";
 /// Saved state of the output builtin.
 pub(crate) const OUTPUT_BUILTIN_STATE: &str = "output_builtin_state";
 
+/// Output builtin segment start.
+pub(crate) const OUTPUT_START: &str = "output_start";
+
 /// Deserialized simple bootloader input.
 pub(crate) const SIMPLE_BOOTLOADER_INPUT: &str = "simple_bootloader_input";
 

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -27,6 +27,7 @@ use super::{
         pack::*,
     },
 };
+use crate::hint_processor::builtin_hint_processor::bootloader::bootloader_hints::compute_and_configure_fact_topologies;
 use crate::hint_processor::builtin_hint_processor::bootloader::execute_task_hints::allocate_program_data_segment;
 use crate::hint_processor::builtin_hint_processor::bootloader::simple_bootloader_hints::{
     divide_num_by_2, prepare_task_range_checks, set_ap_to_zero, set_current_task,
@@ -859,6 +860,9 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                     &hint_data.ids_data,
                     &hint_data.ap_tracking,
                 )
+            }
+            hint_code::BOOTLOADER_COMPUTE_FACT_TOPOLOGIES => {
+                compute_and_configure_fact_topologies(vm, exec_scopes)
             }
             hint_code::BOOTLOADER_SET_PACKED_OUTPUT_TO_SUBTASKS => {
                 set_packed_output_to_subtasks(exec_scopes)

--- a/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -1460,6 +1460,34 @@ pub const BOOTLOADER_SAVE_OUTPUT_POINTER: &str = "output_start = ids.output_ptr"
 
 pub const BOOTLOADER_SAVE_PACKED_OUTPUTS: &str = "packed_outputs = bootloader_input.packed_outputs";
 
+pub const BOOTLOADER_COMPUTE_FACT_TOPOLOGIES: &str = "from typing import List
+
+from starkware.cairo.bootloaders.bootloader.utils import compute_fact_topologies
+from starkware.cairo.bootloaders.fact_topology import FactTopology
+from starkware.cairo.bootloaders.simple_bootloader.utils import (
+    configure_fact_topologies,
+    write_to_fact_topologies_file,
+)
+
+# Compute the fact topologies of the plain packed outputs based on packed_outputs and
+# fact_topologies of the inner tasks.
+plain_fact_topologies: List[FactTopology] = compute_fact_topologies(
+    packed_outputs=packed_outputs, fact_topologies=fact_topologies,
+)
+
+# Configure the memory pages in the output builtin, based on plain_fact_topologies.
+configure_fact_topologies(
+    fact_topologies=plain_fact_topologies, output_start=output_start,
+    output_builtin=output_builtin,
+)
+
+# Dump fact topologies to a json file.
+if bootloader_input.fact_topologies_path is not None:
+    write_to_fact_topologies_file(
+        fact_topologies_path=bootloader_input.fact_topologies_path,
+        fact_topologies=plain_fact_topologies,
+    )";
+
 pub const BOOTLOADER_GUESS_PRE_IMAGE_OF_SUBTASKS_OUTPUT_HASH: &str =
     "data = packed_output.elements_for_hash()
 ids.nested_subtasks_output_len = len(data)

--- a/vm/src/vm/errors/runner_errors.rs
+++ b/vm/src/vm/errors/runner_errors.rs
@@ -101,6 +101,8 @@ pub enum RunnerError {
     StrippedProgramNoMain,
     #[error(transparent)]
     Trace(#[from] TraceError),
+    #[error("Page ({0}) is not on the expected segment {1}")]
+    PageNotOnSegment(Relocatable, usize),
 }
 
 #[cfg(test)]

--- a/vm/src/vm/runners/builtin_runner/output.rs
+++ b/vm/src/vm/runners/builtin_runner/output.rs
@@ -2,7 +2,9 @@ use crate::stdlib::{collections::HashMap, prelude::*};
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
-use crate::vm::runners::cairo_pie::{BuiltinAdditionalData, OutputBuiltinAdditionalData};
+use crate::vm::runners::cairo_pie::{
+    BuiltinAdditionalData, OutputBuiltinAdditionalData, Pages, PublicMemoryPage,
+};
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
@@ -12,6 +14,7 @@ use super::OUTPUT_BUILTIN_NAME;
 #[derive(Debug, Clone)]
 pub struct OutputBuiltinRunner {
     base: usize,
+    pub(crate) pages: Pages,
     pub(crate) stop_ptr: Option<usize>,
     pub(crate) included: bool,
 }
@@ -20,6 +23,7 @@ impl OutputBuiltinRunner {
     pub fn new(included: bool) -> OutputBuiltinRunner {
         OutputBuiltinRunner {
             base: 0,
+            pages: HashMap::default(),
             stop_ptr: None,
             included,
         }
@@ -28,6 +32,7 @@ impl OutputBuiltinRunner {
     pub fn from_segment(segment: &Relocatable, included: bool) -> Self {
         Self {
             base: segment.segment_index as usize,
+            pages: HashMap::default(),
             stop_ptr: None,
             included,
         }
@@ -118,9 +123,30 @@ impl OutputBuiltinRunner {
 
     pub fn get_additional_data(&self) -> BuiltinAdditionalData {
         BuiltinAdditionalData::Output(OutputBuiltinAdditionalData {
-            pages: HashMap::default(),
+            pages: self.pages.clone(),
             attributes: HashMap::default(),
         })
+    }
+
+    pub fn add_page(
+        &mut self,
+        page_id: usize,
+        page_start: Relocatable,
+        page_size: usize,
+    ) -> Result<(), RunnerError> {
+        if page_start.segment_index as usize != self.base {
+            return Err(RunnerError::PageNotOnSegment(page_start, self.base));
+        }
+
+        self.pages.insert(
+            page_id,
+            PublicMemoryPage {
+                start: page_start.offset,
+                size: page_size,
+            },
+        );
+
+        Ok(())
     }
 }
 
@@ -456,6 +482,41 @@ mod tests {
                 pages: HashMap::default(),
                 attributes: HashMap::default()
             })
+        )
+    }
+
+    #[test]
+    fn add_page() {
+        let mut builtin = OutputBuiltinRunner::new(true);
+        assert_eq!(
+            builtin.add_page(
+                1,
+                Relocatable {
+                    segment_index: builtin.base() as isize,
+                    offset: 0
+                },
+                3
+            ),
+            Ok(())
+        );
+
+        assert_eq!(
+            builtin.pages,
+            HashMap::from([(1, PublicMemoryPage { start: 0, size: 3 }),])
+        )
+    }
+
+    #[test]
+    fn add_page_wrong_segment() {
+        let mut builtin = OutputBuiltinRunner::new(true);
+        let page_start = Relocatable {
+            segment_index: 18,
+            offset: 0,
+        };
+
+        let result = builtin.add_page(1, page_start.clone(), 3);
+        assert!(
+            matches!(result, Err(RunnerError::PageNotOnSegment(relocatable, base)) if relocatable == page_start && base == builtin.base())
         )
     }
 }


### PR DESCRIPTION
This hint requires modifications to the `OutputBuiltinRunner` struct. We introduce the concept of pages used in the Python VM and map output pages to fact topologies.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

