### PR TITLE
Feature: support Cairo PIE tasks in bootloader hints

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/execute_task_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/execute_task_hints.rs
@@ -368,9 +368,7 @@ mod tests {
 
     #[rstest]
     fn test_load_program(fibonacci: Program) {
-        let task = Task {
-            program: fibonacci.clone(),
-        };
+        let task = Task::Program(fibonacci.clone());
 
         let mut vm = vm!();
         vm.run_context.fp = 1;
@@ -409,9 +407,7 @@ mod tests {
 
     #[rstest]
     fn test_append_fact_topologies(fibonacci: Program) {
-        let task = Task {
-            program: fibonacci.clone(),
-        };
+        let task = Task::Program(fibonacci.clone());
 
         let mut vm = vm!();
 
@@ -476,9 +472,7 @@ mod tests {
 
     #[rstest]
     fn test_write_output_builtins(field_arithmetic_program: Program) {
-        let task = Task {
-            program: field_arithmetic_program.clone(),
-        };
+        let task = Task::Program(field_arithmetic_program.clone());
 
         let mut vm = vm!();
         // Allocate space for all the builtin list structs (3 x 8 felts).

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/simple_bootloader_hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/simple_bootloader_hints.rs
@@ -171,14 +171,10 @@ mod tests {
             single_page: false,
             tasks: vec![
                 TaskSpec {
-                    task: Task {
-                        program: fibonacci.clone(),
-                    },
+                    task: Task::Program(fibonacci.clone()),
                 },
                 TaskSpec {
-                    task: Task {
-                        program: fibonacci.clone(),
-                    },
+                    task: Task::Program(fibonacci.clone()),
                 },
             ],
         }

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/types.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/types.rs
@@ -5,7 +5,9 @@ use serde::{de, Deserialize, Deserializer};
 use felt::Felt252;
 
 use crate::serde::deserialize_program::deserialize_and_parse_program;
+use crate::types::errors::program_errors::ProgramError;
 use crate::types::program::Program;
+use crate::vm::runners::cairo_pie::StrippedProgram;
 
 pub type BootloaderVersion = u64;
 
@@ -43,8 +45,8 @@ where
 }
 
 impl Task {
-    pub fn get_program(&self) -> &Program {
-        &self.program
+    pub fn get_program(&self) -> Result<StrippedProgram, ProgramError> {
+        self.program.get_stripped_program()
     }
 }
 

--- a/vm/src/vm/runners/cairo_pie.rs
+++ b/vm/src/vm/runners/cairo_pie.rs
@@ -58,7 +58,7 @@ pub enum BuiltinAdditionalData {
     None,
 }
 
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CairoPie {
     pub metadata: CairoPieMetadata,
     #[serde(serialize_with = "serde_impl::serialize_memory")]
@@ -68,7 +68,7 @@ pub struct CairoPie {
     pub version: CairoPieVersion,
 }
 
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CairoPieMetadata {
     pub program: StrippedProgram,
     pub program_segment: SegmentInfo,
@@ -79,7 +79,7 @@ pub struct CairoPieMetadata {
     pub extra_segments: Vec<SegmentInfo>,
 }
 
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct StrippedProgram {
     #[serde(serialize_with = "serde_impl::serialize_program_data")]
     pub data: Vec<MaybeRelocatable>,
@@ -91,7 +91,7 @@ pub struct StrippedProgram {
     pub prime: (),
 }
 
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CairoPieVersion {
     // Dummy field for serialization only.
     #[serde(serialize_with = "serde_impl::serialize_version")]


### PR DESCRIPTION
Add support for Cairo PIE in the bootloader hints. This requires the following changes:
1. Use `StrippedProgram` when working on programs from within hints
2. Make `CairoPie` deserializable
3. Make `Task` an enum. 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

