### PR TITLE
Fix: use correct types for packed outputs in set_packed_output_to_subtasks

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/fact_topologies.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/fact_topologies.rs
@@ -376,7 +376,9 @@ pub fn write_to_fact_topologies_file<FT: AsRef<FactTopology>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hint_processor::builtin_hint_processor::bootloader::types::PackedOutput;
+    use crate::hint_processor::builtin_hint_processor::bootloader::types::{
+        CompositePackedOutput, PackedOutput,
+    };
     use crate::vm::runners::cairo_pie::PublicMemoryPage;
     use rstest::{fixture, rstest};
     use std::collections::HashMap;
@@ -423,7 +425,7 @@ mod tests {
     #[test]
     /// Composite outputs are not supported (yet).
     fn test_compute_fact_topologies_composite_output() {
-        let packed_outputs = vec![PackedOutput::Composite(vec![])];
+        let packed_outputs = vec![PackedOutput::Composite(CompositePackedOutput::default())];
         let fact_topologies = vec![FactTopology {
             tree_structure: vec![],
             page_sizes: vec![],

--- a/vm/src/hint_processor/builtin_hint_processor/bootloader/types.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/bootloader/types.rs
@@ -18,9 +18,22 @@ pub struct BootloaderConfig {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct CompositePackedOutput {
+    pub subtasks: Vec<PackedOutput>,
+}
+
+impl Default for CompositePackedOutput {
+    fn default() -> Self {
+        Self {
+            subtasks: Default::default(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 pub enum PackedOutput {
     Plain(Vec<Felt252>),
-    Composite(Vec<Felt252>),
+    Composite(CompositePackedOutput),
 }
 
 impl PackedOutput {


### PR DESCRIPTION
Replaced the incorrect implementation of `set_packed_output_to_subtasks` by a less incorrect one.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

