### PR TITLE
Implement SECP hints required for k1 and r1 curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* feat: Implement `SECP related` hints [#41](https://github.com/Moonsong-Labs/cairo-vm/pull/41)
+
 #### [1.0.0-rc5] - 2024-07-13
 
 * fix: Fixed deserialization of negative numbers in scientific notation [#1804](https://github.com/lambdaclass/cairo-vm/pull/1804)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,15 +66,15 @@ thiserror-no-std = { version = "2.0.2", default-features = false }
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 
 # Dependencies for cairo-1-hints feature
-cairo-lang-starknet = { version = "2.6.4", default-features = false }
-cairo-lang-casm = { version = "2.6.4", default-features = false }
+cairo-lang-starknet = { version = "=2.6.4", default-features = false }
+cairo-lang-casm = { version = "=2.6.4", default-features = false }
 
-cairo-lang-starknet-classes = { version = "2.6.4", default-features = false }
-cairo-lang-compiler = { version = "2.6.4", default-features = false }
-cairo-lang-sierra-to-casm = { version = "2.6.4", default-features = false }
-cairo-lang-sierra = { version = "2.6.4", default-features = false }
-cairo-lang-runner = { version = "2.6.4", default-features = false }
-cairo-lang-utils = { version = "2.6.4", default-features = false }
+cairo-lang-starknet-classes = { version = "=2.6.4", default-features = false }
+cairo-lang-compiler = { version = "=2.6.4", default-features = false }
+cairo-lang-sierra-to-casm = { version = "=2.6.4", default-features = false }
+cairo-lang-sierra = { version = "=2.6.4", default-features = false }
+cairo-lang-runner = { version = "=2.6.4", default-features = false }
+cairo-lang-utils = { version = "=2.6.4", default-features = false }
 
 # TODO: check these dependencies for wasm compatibility
 ark-ff = { version = "0.4.2", default-features = false }

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -945,6 +945,20 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
+            secp::hints::PACK_X_PRIME_2 => secp::hints::pack_x_prime(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::COMPUTE_VALUE_DIV_MOD => secp::hints::compute_value_div_mod(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
             code => Err(HintError::UnknownHint(code.to_string().into_boxed_str())),
         }
     }

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -938,6 +938,13 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
+            secp::hints::PACK_VALUE_PRIME => secp::hints::pack_value_prime(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
             secp::hints::PACK_X_PRIME => secp::hints::pack_x_prime(
                 vm,
                 exec_scopes,
@@ -945,14 +952,14 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
-            secp::hints::PACK_X_PRIME_2 => secp::hints::pack_x_prime(
+            secp::hints::COMPUTE_VALUE_DIV_MOD => secp::hints::compute_value_div_mod(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
             ),
-            secp::hints::COMPUTE_VALUE_DIV_MOD => secp::hints::compute_value_div_mod(
+            secp::hints::WRITE_DIVMOD_SEGMENT => secp::hints::write_div_mod_segment(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -8,6 +8,7 @@ use super::{
     field_arithmetic::{u256_get_square_root, u384_get_square_root, uint384_div},
     mod_circuit::{run_p_mod_circuit, run_p_mod_circuit_with_large_batch_size},
     secp::{
+        self,
         ec_utils::{
             compute_doubling_slope_external_consts, compute_slope_and_assing_secp_p,
             ec_double_assign_new_y, ec_mul_inner, ec_negate_embedded_secp_p,
@@ -873,6 +874,48 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
                 exec_scopes,
+            ),
+            secp::hints::CALCULATE_VALUE => secp::hints::calculate_value(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::COMPUTE_IDS_HIGH_LOW => secp::hints::compute_ids_high_low(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::COMPUTE_Q_MOD_PRIME => secp::hints::compute_q_mod_prime(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::IS_ON_CURVE_2 => secp::hints::is_on_curve_2(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::MAYBE_WRITE_ADDRESS_TO_AP => secp::hints::maybe_write_address_to_ap(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::PACK_X_PRIME => secp::hints::pack_x_prime(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
             ),
             code => Err(HintError::UnknownHint(code.to_string().into_boxed_str())),
         }

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -882,6 +882,20 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
+            secp::hints::CALCULATE_VALUE_2 => secp::hints::calculate_value_2(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::GENERATE_NIBBLES => secp::hints::generate_nibbles(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
             secp::hints::COMPUTE_IDS_HIGH_LOW => secp::hints::compute_ids_high_low(
                 vm,
                 exec_scopes,

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -875,14 +875,14 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 constants,
                 exec_scopes,
             ),
-            secp::hints::CALCULATE_VALUE => secp::hints::calculate_value(
+            secp::hints::SECP_R1_GET_POINT_FROM_X => secp::hints::r1_get_point_from_x(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
             ),
-            secp::hints::CALCULATE_VALUE_2 => secp::hints::calculate_value_2(
+            secp::hints::SECP_DOUBLE_ASSIGN_NEW_X => secp::hints::double_assign_new_x(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,
@@ -931,21 +931,14 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
-            secp::hints::MAYBE_WRITE_ADDRESS_TO_AP => secp::hints::maybe_write_address_to_ap(
+            secp::hints::SECP_REDUCE => secp::hints::reduce_value(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 constants,
             ),
-            secp::hints::PACK_VALUE_PRIME => secp::hints::pack_value_prime(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
-            secp::hints::PACK_X_PRIME => secp::hints::pack_x_prime(
+            secp::hints::SECP_REDUCE_X => secp::hints::reduce_x(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -896,6 +896,20 @@ impl HintProcessorLogic for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
+            secp::hints::FAST_SECP_ADD_ASSIGN_NEW_Y => secp::hints::fast_secp_add_assign_new_y(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
+            secp::hints::WRITE_NIBBLES_TO_MEM => secp::hints::write_nibbles_to_mem(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                constants,
+            ),
             secp::hints::COMPUTE_IDS_HIGH_LOW => secp::hints::compute_ids_high_low(
                 vm,
                 exec_scopes,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -27,12 +27,12 @@ use num_traits::{One, ToPrimitive, Zero};
 use super::secp_utils::SECP256R1_P;
 
 #[derive(Debug, PartialEq)]
-struct EcPoint<'a> {
-    x: BigInt3<'a>,
-    y: BigInt3<'a>,
+pub(crate) struct EcPoint<'a> {
+    pub(crate) x: BigInt3<'a>,
+    pub(crate) y: BigInt3<'a>,
 }
 impl EcPoint<'_> {
-    fn from_var_name<'a>(
+    pub(crate) fn from_var_name<'a>(
         name: &'a str,
         vm: &'a VirtualMachine,
         ids_data: &'a HashMap<String, HintReference>,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -1,0 +1,499 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use crate::hint_processor::builtin_hint_processor::hint_utils::{
+    get_integer_from_var_name, get_ptr_from_var_name, get_relocatable_from_var_name,
+    insert_value_from_var_name, insert_value_into_ap,
+};
+use crate::hint_processor::hint_processor_definition::HintReference;
+use crate::math_utils::signed_felt;
+use crate::serde::deserialize_program::ApTracking;
+use crate::types::errors::math_errors::MathError;
+use crate::types::exec_scope::ExecutionScopes;
+use crate::vm::errors::hint_errors::HintError;
+use crate::vm::vm_core::VirtualMachine;
+use crate::Felt252;
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::One;
+use num_traits::Zero;
+
+use super::bigint_utils::BigInt3;
+use super::secp_utils::{SECP256R1_ALPHA, SECP256R1_B, SECP256R1_P};
+
+pub const MAYBE_WRITE_ADDRESS_TO_AP: &str = r#"
+    memory[ap] = to_felt_or_relocatable(ids.response.ec_point.address_ if ids.not_on_curve == 0 else segments.add())"#;
+pub fn maybe_write_address_to_ap(
+    vm: &mut VirtualMachine,
+    _exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    _ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let not_on_curve = get_integer_from_var_name("not_on_curve", vm, ids_data, _ap_tracking)?;
+    if not_on_curve == Felt252::ZERO {
+        let response = get_ptr_from_var_name("response", vm, ids_data, _ap_tracking)?;
+        let offset = 1; // SecpNewResponse::ec_point_offset()
+        let ec_point = vm.get_relocatable((response + offset)?)?; //TODO: Use actual struct offset
+        insert_value_into_ap(vm, ec_point)?;
+    } else {
+        let segment = vm.add_memory_segment();
+        insert_value_into_ap(vm, segment)?;
+    }
+    Ok(())
+}
+
+pub const PACK_X_PRIME: &str = r#"
+    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+    from starkware.cairo.common.cairo_secp.secp_utils import pack
+    value = pack(ids.x, PRIME) % SECP256R1_P"#;
+pub fn pack_x_prime(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let x = BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
+    exec_scopes.insert_value("value", x.mod_floor(&SECP256R1_P));
+    Ok(())
+}
+
+pub const COMPUTE_Q_MOD_PRIME: &str = r#"
+    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+    from starkware.cairo.common.cairo_secp.secp_utils import pack
+
+    q, r = divmod(pack(ids.val, PRIME), SECP256R1_P)
+    assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
+    ids.q = q % PRIME"#;
+pub fn compute_q_mod_prime(
+    vm: &mut VirtualMachine,
+    _exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let val = BigInt3::from_var_name("val", vm, ids_data, ap_tracking)?.pack86();
+    let (q, r) = val.div_rem(&SECP256R1_P);
+    if !r.is_zero() {
+        return Err(HintError::SecpVerifyZero(Box::new(val)));
+    }
+    insert_value_from_var_name("q", Felt252::from(&q), vm, ids_data, ap_tracking)?;
+    Ok(())
+}
+
+pub const COMPUTE_IDS_HIGH_LOW: &str = r#"
+        from starkware.cairo.common.math_utils import as_int
+
+        # Correctness check.
+        value = as_int(ids.value, PRIME) % PRIME
+        assert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**165).'
+
+        # Calculation for the assertion.
+        ids.high, ids.low = divmod(ids.value, ids.SHIFT)"#;
+pub fn compute_ids_high_low(
+    vm: &mut VirtualMachine,
+    _exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let upper_bound = get_integer_from_var_name("UPPER_BOUND", vm, ids_data, ap_tracking)?;
+    let value = Felt252::from(&signed_felt(get_integer_from_var_name(
+        "value",
+        vm,
+        ids_data,
+        ap_tracking,
+    )?));
+    if value > upper_bound {
+        return Err(HintError::ValueOutside250BitRange(Box::new(value)));
+    }
+
+    let shift = get_integer_from_var_name("SHIFT", vm, ids_data, ap_tracking)?;
+    let (high, low) = value.div_rem(&shift.try_into().map_err(|_| MathError::DividedByZero)?);
+    insert_value_from_var_name("high", high, vm, ids_data, ap_tracking)?;
+    insert_value_from_var_name("low", low, vm, ids_data, ap_tracking)?;
+    Ok(())
+}
+
+pub const CALCULATE_VALUE: &str = r#"
+    from starkware.cairo.common.cairo_secp.secp_utils import SECP256R1, pack
+    from starkware.python.math_utils import y_squared_from_x
+
+    y_square_int = y_squared_from_x(
+        x=pack(ids.x, SECP256R1.prime),
+        alpha=SECP256R1.alpha,
+        beta=SECP256R1.beta,
+        field_prime=SECP256R1.prime,
+    )
+
+    # Note that (y_square_int ** ((SECP256R1.prime + 1) / 4)) ** 2 =
+    #   = y_square_int ** ((SECP256R1.prime + 1) / 2) =
+    #   = y_square_int ** ((SECP256R1.prime - 1) / 2 + 1) =
+    #   = y_square_int * y_square_int ** ((SECP256R1.prime - 1) / 2) = y_square_int * {+/-}1.
+    y = pow(y_square_int, (SECP256R1.prime + 1) // 4, SECP256R1.prime)
+
+    # We need to decide whether to take y or prime - y.
+    if ids.v % 2 == y % 2:
+        value = y
+    else:
+        value = (-y) % SECP256R1.prime"#;
+
+pub fn calculate_value(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    // def y_squared_from_x(x: int, alpha: int, beta: int, field_prime: int) -> int:
+    // """
+    // Computes y^2 using the curve equation:
+    // y^2 = x^3 + alpha * x + beta (mod field_prime)
+    // """
+    // return (pow(x, 3, field_prime) + alpha * x + beta) % field_prime
+    fn get_y_squared_from_x(x: &BigInt) -> BigInt {
+        (x.modpow(&BigInt::from(3), &SECP256R1_P)
+            + SECP256R1_ALPHA.deref() * x
+            + SECP256R1_B.deref())
+        .mod_floor(&SECP256R1_P)
+    }
+
+    let x = pack_from_var_name("x", ids_data, vm, ap_tracking, &SECP256R1_P)?;
+
+    let y_square_int = get_y_squared_from_x(&x);
+    exec_scopes.insert_value::<BigInt>("y_square_int", y_square_int.clone());
+
+    // Calculate (prime + 1) // 4
+    let exp = (SECP256R1_P.to_owned() + BigInt::one()).div_floor(&BigInt::from(4));
+    // Calculate pow(y_square_int, exp, prime)
+    let y = y_square_int.modpow(&exp, &SECP256R1_P);
+    exec_scopes.insert_value::<BigInt>("y", y.clone());
+
+    let v = get_integer_from_var_name("v", vm, ids_data, ap_tracking)?;
+    let v = BigInt::from(v.to_biguint());
+    if v % 2 == y.clone() % 2 {
+        exec_scopes.insert_value("value", y);
+    } else {
+        let value = (-y).mod_floor(&SECP256R1_P);
+        exec_scopes.insert_value("value", value);
+    }
+    Ok(())
+}
+
+pub const IS_ON_CURVE_2: &str = r#"ids.is_on_curve = (y * y) % SECP256R1.prime == y_square_int"#;
+
+pub fn is_on_curve_2(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let y: BigInt = exec_scopes.get("y")?;
+    let y_square_int: BigInt = exec_scopes.get("y_square_int")?;
+
+    let is_on_curve = ((y.pow(2)) % SECP256R1_P.to_owned()) == y_square_int;
+    insert_value_from_var_name(
+        "is_on_curve",
+        Felt252::from(is_on_curve),
+        vm,
+        ids_data,
+        ap_tracking,
+    )?;
+
+    Ok(())
+}
+
+fn pack_b(d0: &BigInt, d1: &BigInt, d2: &BigInt, prime: &BigInt) -> BigInt {
+    let unreduced_big_int_3 = vec![d0, d1, d2];
+
+    unreduced_big_int_3
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| as_int(value, prime) << (idx * 86))
+        .sum()
+}
+
+/// Returns the lift of the given field element, val, as an integer in the range (-prime/2,
+/// prime/2).
+fn as_int(val: &BigInt, prime: &BigInt) -> BigInt {
+    use std::ops::Shr;
+    // n.shr(1) = n.div_floor(2)
+    if *val < prime.shr(1) {
+        val.clone()
+    } else {
+        val - prime
+    }
+}
+
+fn pack_from_var_name(
+    name: &str,
+    ids: &HashMap<String, HintReference>,
+    vm: &VirtualMachine,
+    hint_ap_tracking: &ApTracking,
+    prime: &BigInt,
+) -> Result<BigInt, HintError> {
+    let to_pack = get_relocatable_from_var_name(name, vm, ids, hint_ap_tracking)?;
+
+    let d0 = vm.get_integer(to_pack)?;
+    let d1 = vm.get_integer((to_pack + 1)?)?;
+    let d2 = vm.get_integer((to_pack + 2)?)?;
+
+    Ok(pack_b(
+        &d0.to_bigint(),
+        &d1.to_bigint(),
+        &d2.to_bigint(),
+        prime,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use assert_matches::assert_matches;
+    use rstest::rstest;
+
+    use crate::utils::test_utils::*;
+
+    use super::*;
+
+    #[rstest]
+    fn test_set_ap_to_ec_point_address() {
+        let mut vm = VirtualMachine::new(false);
+
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        vm.run_context.fp = 4;
+        vm.set_ap(4);
+        // Create hint_data
+        let ids_data = non_continuous_ids_data![("not_on_curve", -2), ("response", -1)];
+        vm.segments = segments![((1, 0), 0), ((1, 1), (2, 0)), ((1, 2), 0), ((1, 3), (1, 0))];
+        maybe_write_address_to_ap(
+            &mut vm,
+            &mut exec_scopes,
+            &ids_data,
+            &ap_tracking,
+            &Default::default(),
+        )
+        .expect("maybe_write_address_to_ap() failed");
+
+        let ap = vm.get_ap();
+
+        let ec_point = vm.get_relocatable(ap).unwrap();
+        assert_eq!(ec_point, (2, 0).into());
+    }
+    #[test]
+    fn test_is_on_curve_2() {
+        let mut vm = VirtualMachine::new(false);
+        vm.set_fp(1);
+        let ids_data = ids_data!["is_on_curve"];
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        let y = BigInt::from(1234);
+        let y_square_int = y.clone() * y.clone();
+
+        exec_scopes.insert_value("y", y);
+        exec_scopes.insert_value("y_square_int", y_square_int);
+
+        is_on_curve_2(
+            &mut vm,
+            &mut exec_scopes,
+            &ids_data,
+            &ap_tracking,
+            &Default::default(),
+        )
+        .expect("is_on_curve2() failed");
+
+        let is_on_curve: Felt252 =
+            get_integer_from_var_name("is_on_curve", &vm, &ids_data, &ap_tracking)
+                .expect("is_on_curve2 should be put in ids_data");
+        assert_eq!(is_on_curve, 1.into());
+    }
+    #[test]
+    fn test_compute_q_mod_prime() {
+        let mut vm = VirtualMachine::new(false);
+
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        vm.run_context.fp = 9;
+        //Create hint data
+        let ids_data = non_continuous_ids_data![("val", -5), ("q", 0)];
+        vm.segments = segments![((1, 4), 0), ((1, 5), 0), ((1, 6), 0)];
+        compute_q_mod_prime(
+            &mut vm,
+            &mut exec_scopes,
+            &ids_data,
+            &ap_tracking,
+            &Default::default(),
+        )
+        .expect("compute_q_mod_prime() failed");
+
+        let q: Felt252 = get_integer_from_var_name("q", &vm, &ids_data, &ap_tracking)
+            .expect("compute_q_mod_prime should have put 'q' in ids_data");
+        assert_eq!(q, Felt252::from(0));
+    }
+
+    #[test]
+    fn test_compute_ids_high_low() {
+        let mut vm = VirtualMachine::new(false);
+
+        let value = BigInt::from(25);
+        let shift = BigInt::from(12);
+
+        vm.set_fp(14);
+        let ids_data = non_continuous_ids_data![
+            ("UPPER_BOUND", -14),
+            ("value", -11),
+            ("high", -8),
+            ("low", -5),
+            ("SHIFT", -2)
+        ];
+
+        vm.segments = segments!(
+            //UPPER_BOUND
+            ((1, 0), 18446744069414584321),
+            ((1, 1), 0),
+            ((1, 2), 0),
+            //value
+            ((1, 3), 25),
+            ((1, 4), 0),
+            ((1, 5), 0),
+            //high
+            ((1, 6), 2),
+            ((1, 7), 0),
+            ((1, 8), 0),
+            //low
+            ((1, 9), 1),
+            ((1, 10), 0),
+            ((1, 11), 0),
+            //SHIFT
+            ((1, 12), 12),
+            ((1, 13), 0),
+            ((1, 14), 0)
+        );
+
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        let constants = HashMap::new();
+        compute_ids_high_low(
+            &mut vm,
+            &mut exec_scopes,
+            &ids_data,
+            &ap_tracking,
+            &constants,
+        )
+        .expect("compute_ids_high_low() failed");
+
+        let high: Felt252 = get_integer_from_var_name("high", &vm, &ids_data, &ap_tracking)
+            .expect("compute_ids_high_low should have put 'high' in ids_data");
+        let low: Felt252 = get_integer_from_var_name("low", &vm, &ids_data, &ap_tracking)
+            .expect("compute_ids_high_low should have put 'low' in ids_data");
+
+        let (expected_high, expected_low) = value.div_rem(&shift);
+        assert_eq!(high, Felt252::from(expected_high));
+        assert_eq!(low, Felt252::from(expected_low));
+    }
+    #[test]
+    fn test_calculate_value() {
+        let mut vm = VirtualMachine::new(false);
+        vm.set_fp(10);
+
+        let ids_data = non_continuous_ids_data![("x", -10), ("v", -7)];
+        vm.segments = segments!(
+            // X
+            ((1, 0), 18446744069414584321),
+            ((1, 1), 0),
+            ((1, 2), 0),
+            // v
+            ((1, 3), 1),
+            ((1, 4), 0),
+            ((1, 5), 0),
+        );
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        let x = BigInt::from(18446744069414584321u128); // Example x value
+        let v = BigInt::from(1); // Example v value (must be 0 or 1 for even/odd check)
+
+        let constants = HashMap::new();
+
+        calculate_value(
+            &mut vm,
+            &mut exec_scopes,
+            &ids_data,
+            &ap_tracking,
+            &constants,
+        )
+        .expect("calculate_value() failed");
+
+        let value: BigInt = exec_scopes
+            .get("value")
+            .expect("value should be calculated and stored in exec_scopes");
+
+        // Compute y_squared_from_x(x)
+        let y_square_int = (x.modpow(&BigInt::from(3), &SECP256R1_P)
+            + SECP256R1_ALPHA.deref() * &x
+            + SECP256R1_B.deref())
+        .mod_floor(&SECP256R1_P);
+
+        // Calculate y = pow(y_square_int, (SECP256R1_P + 1) // 4, SECP256R1_P)
+        let exp = (SECP256R1_P.deref() + BigInt::one()).div_floor(&BigInt::from(4));
+        let y = y_square_int.modpow(&exp, &SECP256R1_P);
+
+        // Determine the expected value based on the parity of v and y
+        let expected_value = if v % 2 == y.clone() % 2 {
+            y
+        } else {
+            (-y).mod_floor(&SECP256R1_P)
+        };
+
+        assert_eq!(value, expected_value);
+    }
+
+    #[test]
+    fn test_pack_x_prime() {
+        let mut vm = VirtualMachine::new(false);
+
+        //Initialize fp
+        vm.run_context.fp = 10;
+
+        //Create hint data
+        let ids_data = non_continuous_ids_data![("x", -5)];
+
+        vm.segments = segments![
+            ((1, 5), ("132181232131231239112312312313213083892150", 10)),
+            ((1, 6), 10),
+            ((1, 7), 10)
+        ];
+
+        let ap_tracking = ApTracking::default();
+
+        let mut exec_scopes = ExecutionScopes::new();
+
+        pack_x_prime(
+            &mut vm,
+            &mut exec_scopes,
+            &ids_data,
+            &ap_tracking,
+            &Default::default(),
+        )
+        .expect("pack_x_prime() failed");
+
+        assert_matches!(
+            exec_scopes.get::<BigInt>("value"),
+            Ok(x) if x == bigint_str!(
+                "59863107065205964761754162760883789350782881856141750"
+            )
+        );
+    }
+}

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::ops::Deref;
+use crate::stdlib::{collections::HashMap, ops::Deref};
 
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
     get_constant_from_var_name, get_integer_from_var_name, get_relocatable_from_var_name,
@@ -437,15 +436,17 @@ fn bls_pack(z: &BigInt3, prime: &BigInt) -> BigInt {
 #[cfg(test)]
 mod tests {
 
-    use std::ops::Deref;
-
     use assert_matches::assert_matches;
 
     use crate::utils::test_utils::*;
 
     use super::*;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_is_on_curve_2() {
         let mut vm = VirtualMachine::new(false);
         vm.set_fp(1);
@@ -475,7 +476,9 @@ mod tests {
                 .expect("is_on_curve2 should be put in ids_data");
         assert_eq!(is_on_curve, 1.into());
     }
+
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_compute_q_mod_prime() {
         let mut vm = VirtualMachine::new(false);
 
@@ -502,6 +505,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_compute_ids_high_low() {
         let mut vm = VirtualMachine::new(false);
 
@@ -569,7 +573,9 @@ mod tests {
         assert_eq!(high, Felt252::from(expected_high));
         assert_eq!(low, Felt252::from(expected_low));
     }
+
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_calculate_value() {
         let mut vm = VirtualMachine::new(false);
         vm.set_fp(10);
@@ -617,8 +623,8 @@ mod tests {
         let exp = (SECP256R1_P.deref() + BigInt::one()).div_floor(&BigInt::from(4));
         let y = y_square_int.modpow(&exp, &SECP256R1_P);
 
-        // Determine the expected value BLS_BASEd on the parity of v and y
-        let expected_value = if v % 2 == y.clone() % 2 {
+        // Determine the expected value based on the parity of v and y
+        let expected_value = if v.is_even() == y.is_even() {
             y
         } else {
             (-y).mod_floor(&SECP256R1_P)
@@ -628,6 +634,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_pack_x_prime() {
         let mut vm = VirtualMachine::new(false);
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -89,9 +89,8 @@ pub fn compute_q_mod_prime(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let secp_p = exec_scopes.get_ref("SECP256R1_P")?;
     let val = Uint384::from_var_name("val", vm, ids_data, ap_tracking)?.pack86();
-    let (q, r) = val.div_mod_floor(&secp_p);
+    let (q, r) = val.div_mod_floor(&SECP256R1_P);
     if !r.is_zero() {
         return Err(HintError::SecpVerifyZero(Box::new(val)));
     }

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
-    get_integer_from_var_name, get_ptr_from_var_name, get_relocatable_from_var_name,
-    insert_value_from_var_name, insert_value_into_ap,
+    get_constant_from_var_name, get_integer_from_var_name, get_ptr_from_var_name, get_relocatable_from_var_name, insert_value_from_var_name, insert_value_into_ap
 };
 use crate::hint_processor::hint_processor_definition::HintReference;
 use crate::math_utils::signed_felt;
@@ -92,16 +91,20 @@ pub fn compute_ids_high_low(
     _exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    _constants: &HashMap<String, Felt252>,
+    constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let upper_bound = get_integer_from_var_name("UPPER_BOUND", vm, ids_data, ap_tracking)?;
+    const UPPER_BOUND: &str = "starkware.cairo.common.math.assert_250_bit.UPPER_BOUND";
+    //Declare constant values
+    let upper_bound = constants
+        .get(UPPER_BOUND)
+        .map_or_else(|| get_constant_from_var_name("UPPER_BOUND", constants), Ok)?;
     let value = Felt252::from(&signed_felt(get_integer_from_var_name(
         "value",
         vm,
         ids_data,
         ap_tracking,
     )?));
-    if value > upper_bound {
+    if &value > upper_bound {
         return Err(HintError::ValueOutside250BitRange(Box::new(value)));
     }
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -20,7 +20,7 @@ use num_integer::Integer;
 use num_traits::Zero;
 use num_traits::{FromPrimitive, One};
 
-use super::bigint_utils::BigInt3;
+use super::bigint_utils::{BigInt3, Uint384};
 use super::ec_utils::EcPoint;
 use super::secp_utils::{bigint3_split, BLS_PRIME, SECP256R1_ALPHA, SECP256R1_B, SECP256R1_P};
 
@@ -89,7 +89,7 @@ pub fn compute_q_mod_prime(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let val = BigInt3::from_var_name("val", vm, ids_data, ap_tracking)?.pack86();
+    let val = Uint384::from_var_name("val", vm, ids_data, ap_tracking)?.pack86();
     let (q, r) = val.div_rem(&SECP256R1_P);
     if !r.is_zero() {
         return Err(HintError::SecpVerifyZero(Box::new(val)));

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -1,4 +1,9 @@
-use crate::stdlib::{collections::HashMap, ops::Deref};
+use crate::stdlib::{
+    collections::HashMap,
+    ops::Deref,
+    ops::{Add, Mul, Rem},
+    prelude::*,
+};
 
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
     get_constant_from_var_name, get_integer_from_var_name, get_relocatable_from_var_name,
@@ -154,7 +159,6 @@ pub fn r1_get_point_from_x(
     // """
     // return (pow(x, 3, field_prime) + alpha * x + beta) % field_prime
     fn y_squared_from_x(x: &BigInt, alpha: &BigInt, beta: &BigInt, field_prime: &BigInt) -> BigInt {
-        use std::ops::{Add, Mul, Rem};
         // Compute x^3 (mod field_prime)
         let x_cubed = x.modpow(&BigInt::from(3), field_prime);
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -518,7 +518,8 @@ mod tests {
     fn test_is_on_curve_2() {
         let mut vm = VirtualMachine::new(false);
         vm.set_fp(1);
-        let ids_data = ids_data!["is_on_curve"];
+        let ids_data = non_continuous_ids_data![("is_on_curve", -1)];
+        vm.segments = segments![((1, 0), 1)];
         let ap_tracking = ApTracking::default();
 
         let mut exec_scopes = ExecutionScopes::new();
@@ -612,7 +613,10 @@ mod tests {
 
         let mut exec_scopes = ExecutionScopes::new();
 
-        let constants = HashMap::new();
+        let constants = HashMap::from([
+            ("UPPER_BOUND".to_string(), Felt252::from(18446744069414584321_u128)),
+            ("SHIFT".to_string(), Felt252::from(12)),
+        ]);
         compute_ids_high_low(
             &mut vm,
             &mut exec_scopes,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -229,8 +229,7 @@ pub fn is_on_curve_2(
     Ok(())
 }
 
-pub const CALCULATE_VALUE_2: &str = r#"
-from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+pub const CALCULATE_VALUE_2: &str = r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
 from starkware.cairo.common.cairo_secp.secp_utils import pack
 
 slope = pack(ids.slope, SECP256R1_P)
@@ -267,8 +266,7 @@ pub fn calculate_value_2(
 }
 
 #[allow(unused)]
-pub const GENERATE_NIBBLES: &str = r#"
-num = (ids.scalar.high << 128) + ids.scalar.low
+pub const GENERATE_NIBBLES: &str = r#"num = (ids.scalar.high << 128) + ids.scalar.low
 nibbles = [(num >> i) & 0xf for i in range(0, 256, 4)]
 ids.first_nibble = nibbles.pop()
 ids.last_nibble = nibbles[0]"#;

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -45,13 +45,25 @@ pub fn maybe_write_address_to_ap(
     Ok(())
 }
 
+pub const PACK_VALUE_PRIME: &str = r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+from starkware.cairo.common.cairo_secp.secp_utils import pack
+value = pack(ids.x, PRIME) % SECP256R1_P"#;
+pub fn pack_value_prime(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let x = BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
+    exec_scopes.insert_value("value", x.mod_floor(&SECP256R1_P));
+    Ok(())
+}
+
 pub const PACK_X_PRIME: &str = r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
 from starkware.cairo.common.cairo_secp.secp_utils import pack
-value = pack(ids.x, PRIME) % SECP256R1_P"#;
-pub const PACK_X_PRIME_2: &str = r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
-from starkware.cairo.common.cairo_secp.secp_utils import pack
 
-value = pack(ids.x, PRIME) % SECP256R1_P"#;
+x = pack(ids.x, PRIME) % SECP256R1_P"#;
 pub fn pack_x_prime(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -316,6 +328,7 @@ pub fn generate_nibbles(
     exec_scopes.insert_value("nibbles", nibbles);
     Ok(())
 }
+
 
 pub const FAST_SECP_ADD_ASSIGN_NEW_Y: &str =
     r#"value = new_y = (slope * (x - new_x) - y) % SECP256R1_P"#;
@@ -649,7 +662,7 @@ mod tests {
 
         let mut exec_scopes = ExecutionScopes::new();
 
-        pack_x_prime(
+        pack_value_prime(
             &mut vm,
             &mut exec_scopes,
             &ids_data,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -409,8 +409,8 @@ pub fn write_div_mod_segment(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let a = BigInt3::from_var_name("a", vm, ids_data, ap_tracking)?.pack86();
-    let b = BigInt3::from_var_name("b", vm, ids_data, ap_tracking)?.pack86();
+    let a = Uint384::from_var_name("a", vm, ids_data, ap_tracking)?.pack86();
+    let b = Uint384::from_var_name("b", vm, ids_data, ap_tracking)?.pack86();
     let (q, r) = (a * b).div_rem(&BLS_PRIME);
     let q_reloc = get_relocatable_from_var_name("q", vm, ids_data, ap_tracking)?;
     let res_reloc = get_relocatable_from_var_name("res", vm, ids_data, ap_tracking)?;

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -72,7 +72,7 @@ pub fn pack_x_prime(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let x = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
-    exec_scopes.insert_value("value", x.mod_floor(&SECP256R1_P));
+    exec_scopes.insert_value("x", x.mod_floor(&SECP256R1_P));
     Ok(())
 }
 
@@ -214,9 +214,8 @@ pub fn calculate_value(
     let y = y_square_int.modpow(&exp, &SECP256R1_P);
     exec_scopes.insert_value::<BigInt>("y", y.clone());
 
-    let v = get_integer_from_var_name("v", vm, ids_data, ap_tracking)?;
-    let v = BigInt::from(v.to_biguint());
-    if v % 2 == y.clone() % 2 {
+    let v = get_integer_from_var_name("v", vm, ids_data, ap_tracking)?.to_biguint();
+    if v.is_even() == y.is_even() {
         exec_scopes.insert_value("value", y);
     } else {
         let value = (-y).mod_floor(&SECP256R1_P);

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -360,7 +360,7 @@ pub fn write_nibbles_to_mem(
 pub const COMPUTE_VALUE_DIV_MOD: &str = r#"from starkware.python.math_utils import div_mod
 value = div_mod(1, x, SECP256R1_P)"#;
 pub fn compute_value_div_mod(
-    vm: &mut VirtualMachine,
+    _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -71,7 +71,7 @@ pub fn pack_x_prime(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let x = BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
+    let x = Uint384::from_var_name("x", vm, ids_data, ap_tracking)?.pack86();
     exec_scopes.insert_value("value", x.mod_floor(&SECP256R1_P));
     Ok(())
 }

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -14,7 +14,7 @@ use crate::types::exec_scope::ExecutionScopes;
 use crate::vm::errors::hint_errors::HintError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::Felt252;
-use num_bigint::{BigInt, BigUint, ToBigInt};
+use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use num_traits::Zero;
 use num_traits::{FromPrimitive, One};
@@ -314,7 +314,7 @@ pub fn generate_nibbles(
 pub const FAST_SECP_ADD_ASSIGN_NEW_Y: &str =
     r#"value = new_y = (slope * (x - new_x) - y) % SECP256R1_P"#;
 pub fn fast_secp_add_assign_new_y(
-    vm: &mut VirtualMachine,
+    _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
@@ -344,7 +344,7 @@ pub fn write_nibbles_to_mem(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let nibbles: &Vec<Felt252> = exec_scopes.get_list_ref("nibbles")?;
+    let nibbles: &mut Vec<Felt252> = exec_scopes.get_mut_list_ref("nibbles")?;
     let nibble = nibbles.pop().unwrap();
     vm.insert_value((vm.get_fp() + 0)?, nibble)?;
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -273,7 +273,7 @@ pub fn calculate_value_2(
     let x = point.x.pack86().mod_floor(&SECP256R1_P);
     let y = point.y.pack86().mod_floor(&SECP256R1_P);
 
-    let value = (slope.pow(2) - (&x << 1u32)).mod_floor(&SECP256R1_P);
+    let value = (slope.modpow(&(2usize.into()), &SECP256R1_P) - (&x << 1u32)).mod_floor(&SECP256R1_P);
 
     //Assign variables to vm scope
     exec_scopes.insert_value("slope", slope);

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -451,7 +451,7 @@ fn bls_split(num: &BigInt) -> Vec<BigInt> {
         a.push(residue);
     }
     a.push(num.clone());
-    assert!(num.abs() < BigInt::from_u64(1 << 127).unwrap());
+    assert!(num.abs() < BigInt::from_u128(1 << 127).unwrap());
     a
 }
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -371,6 +371,7 @@ pub fn write_nibbles_to_mem(
 }
 
 pub const COMPUTE_VALUE_DIV_MOD: &str = r#"from starkware.python.math_utils import div_mod
+
 value = div_mod(1, x, SECP256R1_P)"#;
 pub fn compute_value_div_mod(
     _vm: &mut VirtualMachine,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
-    get_constant_from_var_name, get_integer_from_var_name, get_ptr_from_var_name, get_relocatable_from_var_name, insert_value_from_var_name, insert_value_into_ap
+    get_constant_from_var_name, get_integer_from_var_name, get_ptr_from_var_name,
+    get_relocatable_from_var_name, insert_value_from_var_name, insert_value_into_ap,
 };
 use crate::hint_processor::hint_processor_definition::HintReference;
 use crate::math_utils::signed_felt;
@@ -94,10 +95,14 @@ pub fn compute_ids_high_low(
     constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     const UPPER_BOUND: &str = "starkware.cairo.common.math.assert_250_bit.UPPER_BOUND";
+    const SHIFT: &str = "starkware.cairo.common.math.assert_250_bit.SHIFT";
     //Declare constant values
     let upper_bound = constants
         .get(UPPER_BOUND)
         .map_or_else(|| get_constant_from_var_name("UPPER_BOUND", constants), Ok)?;
+    let shift = constants
+        .get(SHIFT)
+        .map_or_else(|| get_constant_from_var_name("SHIFT", constants), Ok)?;
     let value = Felt252::from(&signed_felt(get_integer_from_var_name(
         "value",
         vm,
@@ -108,7 +113,6 @@ pub fn compute_ids_high_low(
         return Err(HintError::ValueOutside250BitRange(Box::new(value)));
     }
 
-    let shift = get_integer_from_var_name("SHIFT", vm, ids_data, ap_tracking)?;
     let (high, low) = value.div_rem(&shift.try_into().map_err(|_| MathError::DividedByZero)?);
     insert_value_from_var_name("high", high, vm, ids_data, ap_tracking)?;
     insert_value_from_var_name("low", low, vm, ids_data, ap_tracking)?;

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -246,6 +246,7 @@ pub fn calculate_value_2(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
+    exec_scopes.insert_value::<BigInt>("SECP256R1_P", SECP256R1_P.clone());
     //ids.slope
     let slope = BigInt3::from_var_name("slope", vm, ids_data, ap_tracking)?;
     //ids.point

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -21,8 +21,7 @@ use num_traits::Zero;
 use super::bigint_utils::BigInt3;
 use super::secp_utils::{SECP256R1_ALPHA, SECP256R1_B, SECP256R1_P};
 
-pub const MAYBE_WRITE_ADDRESS_TO_AP: &str = r#"
-    memory[ap] = to_felt_or_relocatable(ids.response.ec_point.address_ if ids.not_on_curve == 0 else segments.add())"#;
+pub const MAYBE_WRITE_ADDRESS_TO_AP: &str = r#"memory[ap] = to_felt_or_relocatable(ids.response.ec_point.address_ if ids.not_on_curve == 0 else segments.add())"#;
 pub fn maybe_write_address_to_ap(
     vm: &mut VirtualMachine,
     _exec_scopes: &mut ExecutionScopes,
@@ -43,10 +42,9 @@ pub fn maybe_write_address_to_ap(
     Ok(())
 }
 
-pub const PACK_X_PRIME: &str = r#"
-    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
-    from starkware.cairo.common.cairo_secp.secp_utils import pack
-    value = pack(ids.x, PRIME) % SECP256R1_P"#;
+pub const PACK_X_PRIME: &str = r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+from starkware.cairo.common.cairo_secp.secp_utils import pack
+value = pack(ids.x, PRIME) % SECP256R1_P"#;
 pub fn pack_x_prime(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -59,13 +57,12 @@ pub fn pack_x_prime(
     Ok(())
 }
 
-pub const COMPUTE_Q_MOD_PRIME: &str = r#"
-    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
-    from starkware.cairo.common.cairo_secp.secp_utils import pack
+pub const COMPUTE_Q_MOD_PRIME: &str = r#"from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+from starkware.cairo.common.cairo_secp.secp_utils import pack
 
-    q, r = divmod(pack(ids.val, PRIME), SECP256R1_P)
-    assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
-    ids.q = q % PRIME"#;
+q, r = divmod(pack(ids.val, PRIME), SECP256R1_P)
+assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
+ids.q = q % PRIME"#;
 pub fn compute_q_mod_prime(
     vm: &mut VirtualMachine,
     _exec_scopes: &mut ExecutionScopes,
@@ -82,15 +79,14 @@ pub fn compute_q_mod_prime(
     Ok(())
 }
 
-pub const COMPUTE_IDS_HIGH_LOW: &str = r#"
-        from starkware.cairo.common.math_utils import as_int
+pub const COMPUTE_IDS_HIGH_LOW: &str = r#"from starkware.cairo.common.math_utils import as_int
 
-        # Correctness check.
-        value = as_int(ids.value, PRIME) % PRIME
-        assert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**165).'
+# Correctness check.
+value = as_int(ids.value, PRIME) % PRIME
+assert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**165).'
 
-        # Calculation for the assertion.
-        ids.high, ids.low = divmod(ids.value, ids.SHIFT)"#;
+# Calculation for the assertion.
+ids.high, ids.low = divmod(ids.value, ids.SHIFT)"#;
 pub fn compute_ids_high_low(
     vm: &mut VirtualMachine,
     _exec_scopes: &mut ExecutionScopes,
@@ -116,28 +112,27 @@ pub fn compute_ids_high_low(
     Ok(())
 }
 
-pub const CALCULATE_VALUE: &str = r#"
-    from starkware.cairo.common.cairo_secp.secp_utils import SECP256R1, pack
-    from starkware.python.math_utils import y_squared_from_x
+pub const CALCULATE_VALUE: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP256R1, pack
+from starkware.python.math_utils import y_squared_from_x
 
-    y_square_int = y_squared_from_x(
-        x=pack(ids.x, SECP256R1.prime),
-        alpha=SECP256R1.alpha,
-        beta=SECP256R1.beta,
-        field_prime=SECP256R1.prime,
-    )
+y_square_int = y_squared_from_x(
+    x=pack(ids.x, SECP256R1.prime),
+    alpha=SECP256R1.alpha,
+    beta=SECP256R1.beta,
+    field_prime=SECP256R1.prime,
+)
 
-    # Note that (y_square_int ** ((SECP256R1.prime + 1) / 4)) ** 2 =
-    #   = y_square_int ** ((SECP256R1.prime + 1) / 2) =
-    #   = y_square_int ** ((SECP256R1.prime - 1) / 2 + 1) =
-    #   = y_square_int * y_square_int ** ((SECP256R1.prime - 1) / 2) = y_square_int * {+/-}1.
-    y = pow(y_square_int, (SECP256R1.prime + 1) // 4, SECP256R1.prime)
+# Note that (y_square_int ** ((SECP256R1.prime + 1) / 4)) ** 2 =
+#   = y_square_int ** ((SECP256R1.prime + 1) / 2) =
+#   = y_square_int ** ((SECP256R1.prime - 1) / 2 + 1) =
+#   = y_square_int * y_square_int ** ((SECP256R1.prime - 1) / 2) = y_square_int * {+/-}1.
+y = pow(y_square_int, (SECP256R1.prime + 1) // 4, SECP256R1.prime)
 
-    # We need to decide whether to take y or prime - y.
-    if ids.v % 2 == y % 2:
-        value = y
-    else:
-        value = (-y) % SECP256R1.prime"#;
+# We need to decide whether to take y or prime - y.
+if ids.v % 2 == y % 2:
+    value = y
+else:
+    value = (-y) % SECP256R1.prime"#;
 
 pub fn calculate_value(
     vm: &mut VirtualMachine,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/hints.rs
@@ -84,7 +84,7 @@ assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}
 ids.q = q % PRIME"#;
 pub fn compute_q_mod_prime(
     vm: &mut VirtualMachine,
-    exec_scopes: &mut ExecutionScopes,
+    _exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,

--- a/vm/src/hint_processor/builtin_hint_processor/secp/mod.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/mod.rs
@@ -1,5 +1,6 @@
 pub mod bigint_utils;
 pub mod ec_utils;
 pub mod field_utils;
+pub mod hints;
 pub mod secp_utils;
 pub mod signature;

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -6,7 +6,7 @@ use crate::vm::errors::hint_errors::HintError;
 
 use lazy_static::lazy_static;
 use num_bigint::{BigInt, BigUint};
-use num_traits::{Num, Zero};
+use num_traits::{FromPrimitive, Num, Zero};
 
 // Constants in package "starkware.cairo.common.cairo_secp.constants".
 pub const BASE_86: &str = "starkware.cairo.common.cairo_secp.constants.BASE";
@@ -76,6 +76,8 @@ lazy_static! {
         "52435875175126190479447740508185965837690552500527637822603658699938581184513"
     )
     .unwrap();
+
+    pub(crate) static ref BLS_BASE: BigInt = BigInt::from_u64(2).unwrap().pow(86);
 
 
 }

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -71,6 +71,14 @@ lazy_static! {
         16,
     )
     .unwrap();
+
+    pub(crate) static ref BLS_PRIME: BigInt = BigInt::from_str_radix(
+        "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
+        16,
+    )
+    .unwrap();
+    
+
 }
 
 /*

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -6,7 +6,7 @@ use crate::vm::errors::hint_errors::HintError;
 
 use lazy_static::lazy_static;
 use num_bigint::{BigInt, BigUint};
-use num_traits::Zero;
+use num_traits::{Num, Zero};
 
 // Constants in package "starkware.cairo.common.cairo_secp.constants".
 pub const BASE_86: &str = "starkware.cairo.common.cairo_secp.constants.BASE";
@@ -66,6 +66,11 @@ lazy_static! {
     pub(crate) static ref SECP256R1_ALPHA: BigInt = BigInt::from_str(
         "115792089210356248762697446949407573530086143415290314195533631308867097853948"
     ).unwrap();
+    pub(crate) static ref SECP256R1_B: BigInt = BigInt::from_str_radix(
+        "5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B",
+        16,
+    )
+    .unwrap();
 }
 
 /*

--- a/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -72,12 +72,11 @@ lazy_static! {
     )
     .unwrap();
 
-    pub(crate) static ref BLS_PRIME: BigInt = BigInt::from_str_radix(
-        "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
-        16,
+    pub(crate) static ref BLS_PRIME: BigInt = BigInt::from_str(
+        "52435875175126190479447740508185965837690552500527637822603658699938581184513"
     )
     .unwrap();
-    
+
 
 }
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -120,6 +120,7 @@ pub fn get_point_from_x(
     let y_cube_int = (x_cube_int + beta).mod_floor(&SECP_P);
     // Divide by 4
     let mut y = y_cube_int.modpow(&(&*SECP_P + 1_u32).shr(2_u32), &SECP_P);
+    exec_scopes.insert_value::<BigInt>("y", y.clone());
 
     let v = get_integer_from_var_name("v", vm, ids_data, ap_tracking)?.to_bigint();
     if v.is_even() != y.is_even() {

--- a/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -118,6 +118,7 @@ pub fn get_point_from_x(
         .pack86()
         .mod_floor(&SECP_P);
     let y_cube_int = (x_cube_int + beta).mod_floor(&SECP_P);
+    exec_scopes.insert_value("y_square_int", y_cube_int.clone());
     // Divide by 4
     let mut y = y_cube_int.modpow(&(&*SECP_P + 1_u32).shr(2_u32), &SECP_P);
     exec_scopes.insert_value::<BigInt>("y", y.clone());


### PR DESCRIPTION
# Implement SECP hints required for k1 and r1 curves
Problem: Secp hints are not defined
Solution: Implement them all
## Description
This PR implements secp256(k1|r1) hint processing functions and their unit tests in the Cairo VM

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

