### PR TITLE
Always use a normal segment for first SegmentArena segment

### DIFF
--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -54,7 +54,7 @@ impl DictManagerExecScope {
 
     /// Allocates a new segment for a new dictionary and return the start of the segment.
     pub fn new_default_dict(&mut self, vm: &mut VirtualMachine) -> Result<Relocatable, HintError> {
-        let dict_segment = if self.use_temporary_segments {
+        let dict_segment = if self.use_temporary_segments && self.trackers.len() > 0 {
             vm.add_temporary_segment()
         } else {
             vm.add_memory_segment()


### PR DESCRIPTION
Problem: Starknet OS expects SegmentArena segments to all be temporary except the first segment, which must be normal. This is so that relocation rules for all segments can chain back into the first.

Solution: Use temporary segments only if it's not the first.

# TITLE

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

